### PR TITLE
Make sessions case-insensitive

### DIFF
--- a/lib/session.rb
+++ b/lib/session.rb
@@ -9,7 +9,7 @@ class Session
     @name = name
     @duration = duration
     @connections = []
-    @@sessions[name] = self
+    @@sessions[self.class.to_key(name)] = self
   end
 
   def start
@@ -49,11 +49,15 @@ class Session
   end
 
   def self.find_or_create(name)
-    @@sessions[name] || self.new(name)
+    @@sessions[to_key(name)] || self.new(name)
   end
 
   def self.destroy(name)
-    @@sessions.delete(name)
+    @@sessions.delete(to_key(name))
+  end
+
+  def self.to_key(name)
+    name.upcase
   end
 
 end

--- a/spec/lib/session_spec.rb
+++ b/spec/lib/session_spec.rb
@@ -20,7 +20,12 @@ describe Session do
     it "adds the new session object to a class-level hash of all sessions" do
       expect(Session.class_variable_get(:@@sessions)).to be_empty
       Session.new("new")
-      expect(Session.class_variable_get(:@@sessions)).to have_key "new"
+      expect(Session.class_variable_get(:@@sessions)).not_to be_empty
+    end
+
+    it "creates a case insensitive hash key for session" do
+      Session.new("new sesh")
+      expect(Session.class_variable_get(:@@sessions)).to have_key "NEW SESH"
     end
   end
 
@@ -107,8 +112,14 @@ describe Session do
   describe ".find_or_create" do
     it "returns the requested session if it exists" do
       session = double(Session)
-      Session.class_variable_set(:@@sessions, {"sesh" => session})
-      expect(Session.find_or_create("sesh")).to eq(session)
+      Session.class_variable_set(:@@sessions, {"SESH" => session})
+      expect(Session.find_or_create("SESH")).to eq(session)
+    end
+
+    it "uses case-insensitive matching to return the requested session" do
+      session = double(Session)
+      Session.class_variable_set(:@@sessions, {"SESH" => session})
+      expect(Session.find_or_create("Sesh")).to eq(session)
     end
 
     it "returns a new session if the requested session does not exist" do

--- a/views/index.erb
+++ b/views/index.erb
@@ -6,12 +6,12 @@
 <% if sessions.any? %>
   <h2>Or pick an existing session</h2>
   <ul>
-    <% sessions.keys.each do |session_name| %>
+    <% sessions.each do |key, session| %>
       <li>
-        <a href="/?session=<%= session_name %>" alt="<%= session_name %>">
-          <%= session_name %>
+        <a href="/?session=<%= key %>" alt="<%= session.name %>">
+          <%= session.name %>
         </a>
-        <form class="destroy" method="post" action="/<%= session_name %>">
+        <form class="destroy" method="post" action="/<%= key %>">
           <input type="hidden" name="_method" value="delete"/>
           <button class="destroy" type="submit">&times;</button>
         </form>


### PR DESCRIPTION
Along the way I've created sessions like 'Session name' and 'session name'.
Now my browser history remembers both and I can't remember which one is
the real deal. Even after deleting the wrong one I stupidly end up
creating it again via browser history.

This change just converts the session name to uppercase when accessing the
`sessions` hash. That way it doesn't matter if you type `?session=Blah` or
`?session=blah` - you'll get the same session.
